### PR TITLE
Add missing NDA and Copyright to index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,17 @@
+/*
+/©
+  The following code implements a "collaborative reinvention of error-free architectures"
+  and "SCM system tagging confusion", copyright number 9283F3.
+  It relies on a best-of-breed innovative living standard that can be found here: 
+  https://console.spec.whatwg.org/#log
+©/
+/NDA
+  The following code can only be read if you signed NDA 375-1. If you happen to
+  read it by mistake, send a written letter to our legal department with two
+  attached copies immediately.
+NDA/
+*/
+
 // The following technique of adding a file to fool GitHub into thinking a
 // repo belongs to a certain language is under patent FD3610-8.
 


### PR DESCRIPTION
In case you ever decide to create a JS - Enterprise source-to-source compiler, we could test against this file.